### PR TITLE
Mass based inertia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -95,5 +95,3 @@ ENV/
 
 # Rope project settings
 .ropeproject
-
-.vscode/

--- a/freecad/cross/link.py
+++ b/freecad/cross/link.py
@@ -17,4 +17,5 @@ class Link(fc.DocumentObject):
     MaterialCardPath: str
     MaterialDensity: str
     MaterialNotCalculate: bool
+    CalculateInertiaBasedOnMass:bool
     _Type: str

--- a/freecad/cross/link_proxy.py
+++ b/freecad/cross/link_proxy.py
@@ -153,6 +153,7 @@ class LinkProxy(ProxyBase):
                 'MaterialCardPath',
                 'MaterialDensity',
                 'MaterialNotCalculate',
+                'CalculateInertiaBasedOnMass',
                 '_Type',
             ],
         )
@@ -265,6 +266,10 @@ class LinkProxy(ProxyBase):
         add_property(
             obj, 'App::PropertyBool', 'MaterialNotCalculate', 'Material',
             'If true this material will be not used to calculate mass and inertia of element. In this case you can use manually filled mass and inertia for some elements and auto calculation for others.',
+        )
+        add_property(
+            obj, 'App::PropertyBool', 'CalculateInertiaBasedOnMass', 'Inertial Parameters',
+            'If true and the Mass property is greater than 0, the Mass property will override the material data and be used to calculate the element\'s inertia',
         )
 
         # Used when adding a link which shape in located at the origin but

--- a/freecad/cross/ui/command_calculate_mass_and_inertia.py
+++ b/freecad/cross/ui/command_calculate_mass_and_inertia.py
@@ -103,7 +103,7 @@ class _CalculateMassAndInertiaCommand:
                 material=None
 
             volume = fc.Units.Quantity(elem_volume_mm3, 'mm^3')
-            if not link.MaterialNotCalculate :
+            if not link.CalculateInertiaBasedOnMass :
                 if material is not None:
                     link.Mass = quantity_as(volume * material.density, 'kg')
                 else:


### PR DESCRIPTION
a trivial change to allow moment of inertia to be calculated based on user input to the link mass property  given Material Not calculate set to true and  mass > 0,This adjustment is straightforward, thanks to how well-designed the workbench is